### PR TITLE
Fix Arraya avatar initialization timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -11588,16 +11588,30 @@ const Scene = (()=>{
     return { create };
   })();
 
+  if(typeof ensureArrayaAvatar === 'function'){
+    try{ ensureArrayaAvatar(); }catch(err){ console.warn('Arraya avatar deferred init failed:', err); }
+  }
+
   // Celli and Arraya avatars
   let celli, arraya, arrayaAvatar;
+  function ensureArrayaAvatar(){
+    if(arrayaAvatar || typeof ArrayaAvatarFactory === 'undefined') return;
+    try{
+      const created = ArrayaAvatarFactory.create(THREE);
+      if(!created) return;
+      arrayaAvatar = created;
+      arraya = arrayaAvatar.group;
+      if(scene && arraya) scene.add(arraya);
+      arrayaAvatar.setVisible(false);
+    }catch(err){
+      console.error('Failed to initialize Arraya avatar:', err);
+    }
+  }
   function initAvatars(){
     celli = AvatarFactory.createCelli(THREE);
     scene.add(celli); celli.visible=false;
 
-    arrayaAvatar = ArrayaAvatarFactory.create(THREE);
-    arraya = arrayaAvatar.group;
-    scene.add(arraya);
-    arrayaAvatar.setVisible(false);
+    ensureArrayaAvatar();
   }
 
   function updateAvatars(sel){
@@ -11612,6 +11626,7 @@ const Scene = (()=>{
 
     const cell=UI.getCell(sel.arrayId,sel.focus);
     const hasArray=(cell.formula||'').toUpperCase().includes('ARRAY');
+    ensureArrayaAvatar();
     if(arrayaAvatar){
       arrayaAvatar.setVisible(hasArray);
       if(hasArray){


### PR DESCRIPTION
## Summary
- guard Arraya avatar creation until the factory is ready
- lazily initialize the avatar so the scene no longer crashes at startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df3fc48b18832994074537e8c3372e