### PR TITLE
Fix scale helper reference and guard orbit control suspension

### DIFF
--- a/index.html
+++ b/index.html
@@ -2577,6 +2577,21 @@ function parseVectorArg(arg){
   }
   return null;
 }
+
+function arrayScaleUnitsFromLevel(level){
+  const lvl = Math.max(1, Math.round(Number(level)||1));
+  return Math.pow(2, Math.max(0, lvl-1));
+}
+
+function arrayVoxelScale(arr){
+  if(!arr || typeof arr !== 'object') return 1;
+  const params = arr.params || {};
+  const direct = Number(params.voxelScale);
+  if(Number.isFinite(direct) && direct > 0) return direct;
+  const level = Number(params.voxelScaleLevel);
+  if(Number.isFinite(level) && level >= 1) return arrayScaleUnitsFromLevel(level);
+  return 1;
+}
 // helper: policy check with proper tag filtering
 function isAllowed(arr, fnName){
   if(ALWAYS.has(fnName)) return true;
@@ -9226,19 +9241,7 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
     }catch{}
   }
   
-  function arrayScaleUnitsFromLevel(level){
-    const lvl = Math.max(1, Math.round(Number(level)||1));
-    return Math.pow(2, Math.max(0, lvl-1));
-  }
-  function arrayVoxelScale(arr){
-    if(!arr || typeof arr !== 'object') return 1;
-    const params = arr.params || {};
-    const direct = Number(params.voxelScale);
-    if(Number.isFinite(direct) && direct > 0) return direct;
-    const level = Number(params.voxelScaleLevel);
-    if(Number.isFinite(level) && level >= 1) return arrayScaleUnitsFromLevel(level);
-    return 1;
-  }
+  
   function worldPos(arr,x,y,z){
     const base = localPos(arr,x,y,z);
     const off = arr.offset||{x:0,y:0,z:0};
@@ -11633,8 +11636,8 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
       // Ensure controls remain enabled when physics is off
       const physicsEnabled = Store.getState().scene.physics;
       if(!physicsEnabled){
-        // Force controls to stay enabled when physics is disabled
-        if(controls){
+        // Force controls to stay enabled when physics is disabled unless orbit is intentionally suspended
+        if(controls && orbitSuspendDepth === 0){
           controls.enabled = true;
           controls.enableRotate = true;
           controls.enablePan = true;
@@ -15460,10 +15463,14 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
       }catch{}
       // Explicitly re-enable orbit controls when physics is disabled
       if(controls){
-        controls.enableRotate = true;
-        controls.enablePan = true;
-        controls.enabled = true;
-        console.log('[PHYSICS] Orbit controls re-enabled');
+        if(orbitSuspendDepth === 0){
+          controls.enableRotate = true;
+          controls.enablePan = true;
+          controls.enabled = true;
+          console.log('[PHYSICS] Orbit controls re-enabled');
+        } else {
+          console.log('[PHYSICS] Orbit controls remain suspended (depth:', orbitSuspendDepth, ')');
+        }
       }
       document.getElementById('physChip').textContent='Physics: OFF';
     }


### PR DESCRIPTION
## Summary
- add shared voxel scale helper accessible to SCALE formulas and scene utilities
- prevent physics cleanup from re-enabling orbit controls while drag interactions suspend them

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2abb9191c8329bfc043f72b5ad3c8