### PR TITLE
Fix physics debug snapshot keying

### DIFF
--- a/index.html
+++ b/index.html
@@ -8506,7 +8506,7 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
           if(!arr) return;
           const nextParams = { ...(arr.params || {}) };
           const prevPhysics = nextParams.physics ? { ...nextParams.physics } : null;
-          snapshot.arrays.set(Number(id), prevPhysics);
+          snapshot.arrays.set(id, prevPhysics);
           nextParams.physics = { ...(nextParams.physics || {}), enabled:true };
           arrays[id] = { ...arr, params: nextParams };
         });
@@ -8524,7 +8524,7 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
       const arrays = { ...state.arrays };
       Object.entries(arrays).forEach(([id, arr])=>{
         if(!arr) return;
-        const prev = snapshot.arrays.get(Number(id));
+        const prev = snapshot.arrays.get(id);
         if(prev){
           const nextParams = { ...(arr.params || {}) };
           nextParams.physics = { ...prev };


### PR DESCRIPTION
## Summary
- ensure debug physics snapshot stores array states by their actual identifiers
- correctly restore physics settings per array after disabling debug overrides

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2db568b7c8329b3ca51016c567306