### PR TITLE
Restore classic Celli styling and refine selection UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -10099,19 +10099,23 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
     data.mouthFrame.position.set(0,0,(bodyDepth - mouthDepth)/2);
 
     const faceZ = bodyDepth/2 + 0.02;
+    const totalWidth = innerWidth;
+    const totalHeight = innerHeight;
+    const halfWidth = totalWidth / 2;
+    const halfHeight = totalHeight / 2;
     const featureSpan = Math.min(innerWidth, innerHeight);
-    const eyeSpacing = Math.min(Math.max(scale * 0.28, featureSpan * 0.32), outerWidth * 0.34);
-    const eyeVerticalOffset = Math.min(Math.max(scale * 0.12, featureSpan * 0.18), outerHeight * 0.22);
-    const eyeHeight = Math.max(-innerHeight * 0.05, (innerHeight / 2) - eyeVerticalOffset);
-    const eyeScale = Math.max(0.8, Math.min(1.25, featureSpan * 0.32));
+
+    const eyeSpacing = Math.min(halfWidth - scale * 0.02, totalWidth * (0.12 / 0.8));
+    const eyeHeight = Math.min(halfHeight - scale * 0.02, totalHeight * (0.13 / 0.8));
+    const eyeScale = Math.max(0.85, Math.min(1.3, featureSpan * 0.32));
     data.eyeLeft.scale.set(eyeScale, eyeScale, 1);
     data.eyeRight.scale.copy(data.eyeLeft.scale);
     data.eyeLeft.position.set(-eyeSpacing, eyeHeight, faceZ);
     data.eyeRight.position.set(eyeSpacing, eyeHeight, faceZ);
 
-    const cheekSpacing = Math.min(Math.max(scale * 0.34, featureSpan * 0.38), outerWidth * 0.4);
-    const cheekHeight = -Math.min(Math.max(scale * 0.05, featureSpan * 0.08), outerHeight * 0.12);
-    const cheekScale = Math.max(0.85, Math.min(1.35, featureSpan * 0.34));
+    const cheekSpacing = Math.min(halfWidth - scale * 0.015, totalWidth * (0.25 / 0.8));
+    const cheekHeight = -Math.min(halfHeight - scale * 0.015, totalHeight * (0.08 / 0.8));
+    const cheekScale = Math.max(0.9, Math.min(1.35, featureSpan * 0.34));
     data.cheekLeft.scale.set(cheekScale, cheekScale, 1);
     data.cheekRight.scale.copy(data.cheekLeft.scale);
     data.cheekLeft.position.set(-cheekSpacing, cheekHeight, faceZ - 0.01);
@@ -14751,38 +14755,21 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
   // Lightweight AvatarFactory for modular characters
   const AvatarFactory = {
     createCelli(THREE){
-      const MAT_BODY  = new THREE.MeshLambertMaterial({ color: 0xf59e0b });
-      const MAT_DARK  = new THREE.MeshLambertMaterial({ color: 0x374151 });
-      const MAT_BLUSH = new THREE.MeshLambertMaterial({ color: 0xec4899 });
-      const MAT_WING  = new THREE.MeshLambertMaterial({ color: 0xfbbf24, side: THREE.DoubleSide });
-      const MAT_OUTLINE = new THREE.MeshBasicMaterial({ color: 0x111827 });
-      MAT_OUTLINE.depthTest = true;
-      MAT_OUTLINE.depthWrite = false;
-      MAT_OUTLINE.toneMapped = false;
-      const root = new THREE.Group();
-      root.scale.setScalar(0.40);
-      // Body
-      const BW=.8, BH=.8, BD=.3;
-      const bodyGroup = new THREE.Group();
-      const body = new THREE.Mesh(new RoundedBoxGeometry(BW, BH, BD, 6, .10), MAT_BODY);
-      bodyGroup.add(body); bodyGroup.position.y = BH/2; root.add(bodyGroup);
-      // Face cluster
-      const faceGroup = new THREE.Group();
-      const faceZ = BD/2 + 0.01;
-      const eyeGeo = new THREE.SphereGeometry(0.05, 16, 12);
-      const eyeL = new THREE.Mesh(eyeGeo, MAT_DARK); eyeL.scale.set(1.05,2.2,.25); eyeL.position.set(-.18,.18,faceZ);
-      const eyeR = new THREE.Mesh(eyeGeo, MAT_DARK); eyeR.scale.set(1.05,2.2,.25); eyeR.position.set(.18,.18,faceZ);
-      const blushGeo = new THREE.SphereGeometry(0.05, 16, 12);
-      const cheekL = new THREE.Mesh(blushGeo, MAT_BLUSH); cheekL.scale.set(1.35,1.05,.22); cheekL.position.set(-.30,0.0,faceZ);
-      const cheekR = new THREE.Mesh(blushGeo, MAT_BLUSH); cheekR.scale.set(1.35,1.05,.22); cheekR.position.set(.30,0.0,faceZ);
-      const smileShape = new THREE.Shape();
-      smileShape.moveTo(-0.12, -0.06);
-      smileShape.quadraticCurveTo(0, -0.25, 0.12, -0.06);
-      smileShape.quadraticCurveTo(0, -0.20, -0.12, -0.06);
-      const smile = new THREE.Mesh(new THREE.ShapeGeometry(smileShape), MAT_DARK); smile.position.set(0,-0.06,faceZ);
-      faceGroup.add(eyeL, eyeR, cheekL, cheekR, smile);
-      bodyGroup.add(faceGroup);
-      // Bow
+      const MAT_BODY = new THREE.MeshToonMaterial({ color: 0xf59e0b });
+      const MAT_DARK = new THREE.MeshToonMaterial({ color: 0x374151 });
+      const MAT_BLUSH = new THREE.MeshToonMaterial({ color: 0xec4899 });
+      const MAT_WING = new THREE.MeshToonMaterial({ color: 0xf59e0b, side: THREE.DoubleSide });
+
+      function addOutline(child, scale=1.06){
+        const outlineMat = new THREE.MeshBasicMaterial({ color: MAT_DARK.color.getHex(), side: THREE.BackSide });
+        const outline = new THREE.Mesh(child.geometry, outlineMat);
+        outline.scale.setScalar(scale);
+        outline.userData.isAvatarOutline = true;
+        outline.renderOrder = 10499;
+        child.add(outline);
+        return outline;
+      }
+
       function triWing(width=0.22, height=0.16, depth=0.02){
         const shape = new THREE.Shape();
         shape.moveTo(width/2, 0);
@@ -14790,45 +14777,77 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
         shape.lineTo(-width/2, -height/2);
         shape.lineTo(width/2, 0);
         const geo = new THREE.ExtrudeGeometry(shape, { depth, bevelEnabled:false });
-        geo.center(); geo.computeVertexNormals();
+        geo.center();
+        geo.computeVertexNormals();
         return geo;
       }
+
+      const root = new THREE.Group();
+      root.scale.setScalar(0.40);
+
+      const BW=.8, BH=.8, BD=.3;
+      const bodyGroup = new THREE.Group();
+      const body = new THREE.Mesh(new RoundedBoxGeometry(BW, BH, BD, 6, .12), MAT_BODY);
+      addOutline(body);
+      bodyGroup.add(body);
+      bodyGroup.position.y = BH/2;
+
+      const faceGroup = new THREE.Group();
+      const faceZ = BD/2 + 0.01;
+      const eyeGeo = new THREE.SphereGeometry(0.05, 16, 12);
+      const eyeL = new THREE.Mesh(eyeGeo, MAT_DARK); addOutline(eyeL); eyeL.scale.set(1, 2, .25); eyeL.position.set(-.12,.13,faceZ);
+      const eyeR = new THREE.Mesh(eyeGeo, MAT_DARK); addOutline(eyeR); eyeR.scale.set(1, 2, .25); eyeR.position.set(.12,.13,faceZ);
+      const blushGeo = new THREE.SphereGeometry(0.05, 16, 12);
+      const cheekL = new THREE.Mesh(blushGeo, MAT_BLUSH); addOutline(cheekL); cheekL.scale.set(1.2,1,.2); cheekL.position.set(-.25,-.08,faceZ);
+      const cheekR = new THREE.Mesh(blushGeo, MAT_BLUSH); addOutline(cheekR); cheekR.scale.set(1.2,1,.2); cheekR.position.set(.25,-.08,faceZ);
+      const smileShape = new THREE.Shape();
+      smileShape.moveTo(-0.12, -0.06);
+      smileShape.quadraticCurveTo(0, -0.25, 0.12, -0.06);
+      smileShape.quadraticCurveTo(0, -0.20, -0.12, -0.06);
+      const smile = new THREE.Mesh(new THREE.ShapeGeometry(smileShape), MAT_DARK); addOutline(smile);
+      smile.position.z = faceZ;
+      faceGroup.add(eyeL, eyeR, cheekL, cheekR, smile);
+      bodyGroup.add(faceGroup);
+
       const bowGroup = new THREE.Group();
-      const wingL = new THREE.Mesh(triWing(), MAT_WING);
-      const wingR = new THREE.Mesh(triWing(), MAT_WING);
-      wingL.rotation.y = 0; wingR.rotation.y = Math.PI;
-      wingL.position.set(-0.18, 0, 0); wingR.position.set(0.18, 0, 0);
-      const knot = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.06, 0.06), MAT_BODY);
+      const wingL = new THREE.Mesh(triWing(), MAT_WING); addOutline(wingL);
+      const wingR = new THREE.Mesh(triWing(), MAT_WING); addOutline(wingR);
+      wingL.rotation.y = 0;
+      wingR.rotation.y = Math.PI;
+      wingL.position.set(-0.18, 0, 0);
+      wingR.position.set(0.18, 0, 0);
+      const knot = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.06, 0.06), MAT_BODY); addOutline(knot);
       bowGroup.add(wingL, wingR, knot);
-      bowGroup.position.set(0, BH + 0.12, BD/2 - 0.04);
-      bowGroup.rotation.x = -0.2;
-      root.add(bowGroup);
-      // Arms
+      bowGroup.position.set(0, BH + 0.15, 0);
+
       const armRadius = .055;
       const armCurve = new THREE.QuadraticBezierCurve3(
-        new THREE.Vector3(0, 0.04, 0),
-        new THREE.Vector3(0.15, -0.04, 0.08),
-        new THREE.Vector3(0.20, -0.22, 0)
+        new THREE.Vector3(0, 0.02, 0),
+        new THREE.Vector3(0.12, -0.08, 0.05),
+        new THREE.Vector3(0.16, -0.20, 0)
       );
       const armGeo = new THREE.TubeGeometry(armCurve, 28, armRadius, 12, false);
       const handGeo = new THREE.SphereGeometry(armRadius, 16, 12);
       function makeArm(sign=1){
         const armRoot = new THREE.Group();
-        const upper = new THREE.Mesh(armGeo, MAT_BODY);
+        const upper = new THREE.Mesh(armGeo, MAT_BODY); addOutline(upper, 1.04);
         const handGroup = new THREE.Group();
-        const hand = new THREE.Mesh(handGeo, MAT_BODY);
-        hand.position.copy(armCurve.getPoint(1)); handGroup.add(hand);
+        const hand = new THREE.Mesh(handGeo, MAT_BODY); addOutline(hand, 1.04);
+        hand.position.copy(armCurve.getPoint(1));
+        handGroup.add(hand);
         armRoot.add(upper, handGroup);
-        armRoot.position.set(sign*(BW/2 - 0.02), BH*.56, 0);
+        armRoot.position.set(sign*(BW/2), BH*.90, 0);
         armRoot.scale.x *= sign;
-        armRoot.rotation.z = sign * (Math.PI/180) * 8;
+        armRoot.rotation.z = sign * (Math.PI/180) * 6;
+        armRoot.rotation.x = (Math.PI/180) * -10;
         return { armRoot, handGroup };
       }
       const L = makeArm(-1), R = makeArm(+1);
       R.armRoot.position.set(Math.abs(L.armRoot.position.x), L.armRoot.position.y, L.armRoot.position.z);
       R.armRoot.rotation.set(L.armRoot.rotation.x, -L.armRoot.rotation.y, -L.armRoot.rotation.z);
-      R.armRoot.scale.y = L.armRoot.scale.y; R.armRoot.scale.z = -L.armRoot.scale.z;
-      // Legs
+      R.armRoot.scale.y = L.armRoot.scale.y;
+      R.armRoot.scale.z = -L.armRoot.scale.z;
+
       const legRadius = .06;
       const legCurve = new THREE.CatmullRomCurve3([
         new THREE.Vector3(0,0,0), new THREE.Vector3(0,-.10,.022), new THREE.Vector3(0,-.17,.036)
@@ -14837,52 +14856,64 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
       const footGeo = new THREE.SphereGeometry(legRadius, 16, 12);
       function makeLeg(x){
         const legRoot = new THREE.Group();
-        const leg = new THREE.Mesh(legGeo, MAT_BODY);
+        const leg = new THREE.Mesh(legGeo, MAT_BODY); addOutline(leg, 1.04);
         const footGroup = new THREE.Group();
-        const foot = new THREE.Mesh(footGeo, MAT_BODY);
-        foot.position.copy(legCurve.getPoint(1)); foot.scale.set(1.5,.8,1.2); footGroup.add(foot);
-        legRoot.add(leg, footGroup); legRoot.position.set(x, 0, 0);
+        const foot = new THREE.Mesh(footGeo, MAT_BODY); addOutline(foot, 1.04);
+        foot.position.copy(legCurve.getPoint(1));
+        foot.scale.set(1.5,.8,1.2);
+        footGroup.add(foot);
+        legRoot.add(leg, footGroup);
+        legRoot.position.set(x, 0, 0);
         return { legRoot, footGroup };
       }
       const legL = makeLeg(-.20), legR = makeLeg(.20);
       legR.legRoot.position.set(Math.abs(legL.legRoot.position.x), legL.legRoot.position.y, legL.legRoot.position.z);
-      root.add(bodyGroup, L.armRoot, R.armRoot, legL.legRoot, legR.legRoot);
-      const baseMeshes = [];
-      root.traverse(n=>{ if(n.isMesh) baseMeshes.push(n); });
-      baseMeshes.forEach(mesh=>{
-        const outline = new THREE.Mesh(mesh.geometry, MAT_OUTLINE);
-        outline.name = `${mesh.name||'part'}_outline`;
-        outline.userData.isAvatarOutline = true;
-        outline.scale.set(1.03,1.03,1.03);
-        outline.position.set(0,0,0);
-        outline.castShadow = false;
-        outline.receiveShadow = false;
-        mesh.add(outline);
-      });
-      // Ensure overlay rendering above voxels
+
+      root.add(bodyGroup, bowGroup, L.armRoot, R.armRoot, legL.legRoot, legR.legRoot);
+
       const BASE_RENDER_ORDER = 10500;
-      root.traverse(n=>{
-        if(!n.isMesh) return;
-        const isOutline = !!n.userData?.isAvatarOutline;
-        if(n.material){
-          if(!n.material.transparent){
-            n.material.transparent = true;
-            n.material.opacity = 1;
-          }
-          n.material.depthTest = true;
-          n.material.depthWrite = !isOutline;
+      root.traverse(obj=>{
+        if(!obj.isMesh) return;
+        const isOutline = !!obj.userData?.isAvatarOutline;
+        if(obj.material){
+          obj.material.depthTest = true;
+          obj.material.depthWrite = !isOutline;
+          obj.material.toneMapped = false;
           if(isOutline){
-            n.material.polygonOffset = true;
-            n.material.polygonOffsetFactor = -1;
-            n.material.polygonOffsetUnits = -1;
-          } else if(n.material.polygonOffset){
-            n.material.polygonOffset = false;
+            obj.material.transparent = true;
+            obj.material.opacity = 1;
+            obj.material.polygonOffset = true;
+            obj.material.polygonOffsetFactor = -1;
+            obj.material.polygonOffsetUnits = -1;
+          } else if(obj.material.polygonOffset){
+            obj.material.polygonOffset = false;
           }
-          if(n.material.toneMapped !== false) n.material.toneMapped = false;
-          try{ n.material.needsUpdate = true; }catch{}
         }
-        n.renderOrder = isOutline ? (BASE_RENDER_ORDER - 1) : BASE_RENDER_ORDER;
+        obj.renderOrder = isOutline ? (BASE_RENDER_ORDER - 1) : BASE_RENDER_ORDER;
       });
+
+      root.userData.components = [
+        {name:'Body', group: bodyGroup},
+        {name:'Face', group: faceGroup},
+        {name:'Eye L', group: eyeL},
+        {name:'Eye R', group: eyeR},
+        {name:'Cheek L', group: cheekL},
+        {name:'Cheek R', group: cheekR},
+        {name:'Bow', group: bowGroup},
+        {name:'Bow / Left', group: wingL},
+        {name:'Bow / Right', group: wingR},
+        {name:'Bow / Center', group: knot},
+        {name:'Arm L', group: L.armRoot},
+        {name:'Arm L / Hand', group: L.handGroup},
+        {name:'Arm R', group: R.armRoot},
+        {name:'Arm R / Hand', group: R.handGroup},
+        {name:'Leg L', group: legL.legRoot},
+        {name:'Leg L / Foot', group: legL.legRoot.children[1]},
+        {name:'Leg R', group: legR.legRoot},
+        {name:'Leg R / Foot', group: legR.legRoot.children[1]},
+      ];
+
+      root.userData.bodyGroup = bodyGroup;
       return root;
     }
   };
@@ -15513,6 +15544,22 @@ let physicsCameraConfig = { mode:'free', distance:10, allowRotation:false };
     }
     const arr=Store.getState().arrays[sel.arrayId];
     const pos=worldPos(arr,sel.focus.x,sel.focus.y,sel.focus.z);
+
+    let multiSelect = false;
+    if(sel.range){
+      const sx = sel.range.x1 ?? sel.range.x ?? sel.focus.x;
+      const ex = sel.range.x2 ?? sel.range.x ?? sel.focus.x;
+      const sy = sel.range.y1 ?? sel.range.y ?? sel.focus.y;
+      const ey = sel.range.y2 ?? sel.range.y ?? sel.focus.y;
+      const sz = sel.range.z1 ?? sel.range.z ?? sel.focus.z;
+      const ez = sel.range.z2 ?? sel.range.z ?? sel.focus.z;
+      multiSelect = (sx !== ex) || (sy !== ey) || (sz !== ez);
+    }
+    if(multiSelect){
+      celli.visible = false;
+      if(arrayaAvatar) arrayaAvatar.setVisible(false);
+      return;
+    }
     
     let cell = null;
     try{ cell = UI.getCell(sel.arrayId,sel.focus); }catch{}


### PR DESCRIPTION
## Summary
- restore Celli's construction to the classic toon-styled materials with outlines and slightly lowered, shorter arms
- update selection frame facial feature placement to follow the original spacing ratios and hide the 3D avatar for multi-select ranges

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e32ada95508329932bf861cb078c07