### PR TITLE
Align ty.txt acknowledgments formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,9 +634,8 @@ document.addEventListener('click', function(e){
 - Stephen Lavelle (Increpare)
 - Arvi Teikari (Hempuli)
 - Jonathan Blow
-
-Hideo Kojima
-Alan Moore
+- Hideo Kojima
+- Alan Moore
 
 Synthesize what you love, make what you can.
 


### PR DESCRIPTION
## Summary
- add hyphen-prefixed entries for Hideo Kojima and Alan Moore in the ty.txt notepad so they match the other acknowledgments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33fc74dd88329a6fe65c0531b222e