### PR TITLE
Fix collider rebuild for CELL_PHYS arrays

### DIFF
--- a/index.html
+++ b/index.html
@@ -6872,9 +6872,12 @@ tag('CELL_PHYS',["PHYSICS"], (anchor, arr, ast) => {
   });
   
   if(enabled){
-    targetList.forEach(targetArr=>{ 
-      console.log(`[CELL_PHYS] Rebuilding colliders for array #${targetArr.id} with enabled=${targetArr.params?.physics?.enabled}`);
-      try{ Scene.debounceColliderRebuild(targetArr); }catch{} 
+    const arraysById = Store.getState().arrays || {};
+    targetList.forEach(targetArr=>{
+      const latest = arraysById[targetArr.id] || null;
+      console.log(`[CELL_PHYS] Rebuilding colliders for array #${targetArr.id} with enabled=${latest?.params?.physics?.enabled}`);
+      if(!latest) return;
+      try{ Scene.debounceColliderRebuild(latest); }catch{}
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure CELL_PHYS collider rebuilds use the latest array state from the store
- avoid passing stale array metadata so physics-enabled arrays rebuild colliders correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45bfa0fc08329985442978b9ed46a