### PR TITLE
Fix touch sheet anchoring and restore button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7853,7 +7853,8 @@ tag('MINIMIZE',["ACTION"],(anchor,arr,ast)=>{
         sheet.dataset.prevOpacity = sheet.style.opacity||'';
         sheet.dataset.prevPointer = sheet.style.pointerEvents||'';
       }
-      sheet.style.transform = (sheet.style.transform.includes('translateX(-50%)')? 'translateX(-50%)' : '') + ' translateY(12px) scale(0.92)';
+      const base=(document.body.classList.contains('touch') && sheet.dataset.touchFreed!=='1')?'translateX(-50%) ':'';
+      sheet.style.transform = `${base}translateY(12px) scale(0.92)`;
       sheet.style.opacity='0.0';
       sheet.style.pointerEvents='none';
     } else {
@@ -7868,7 +7869,11 @@ tag('MINIMIZE',["ACTION"],(anchor,arr,ast)=>{
         delete sheet.dataset.prevTransform; delete sheet.dataset.prevOpacity; delete sheet.dataset.prevPointer;
       } else {
         sheet.style.opacity='1'; sheet.style.pointerEvents='auto';
-        if(sheet.style.transform.includes('translateX(-50%)')){ sheet.style.transform='translateX(-50%)'; } else { sheet.style.transform=''; }
+        if(document.body.classList.contains('touch')){
+          sheet.style.transform = (sheet.dataset.touchFreed==='1') ? 'none' : 'translateX(-50%)';
+        } else {
+          sheet.style.transform='';
+        }
       }
     }
     Actions.setCell(arr.id, anchor, `Minimize:${flag?1:0}`, ast.raw, true);
@@ -18752,7 +18757,8 @@ const UI = (()=>{
     const sheetEl=document.getElementById('sheet'); let drag=false, sx=0, sy=0, sl=0, st=0, prevTrans='';
     const beginDrag=(clientX, clientY)=>{ drag=true; sheetEl.classList.add('dragging'); sx=clientX; sy=clientY; const r=sheetEl.getBoundingClientRect(); sl=r.left; st=r.top; prevTrans=sheetEl.style.transition; sheetEl.style.transition='none'; // kill easing
       // If mobile intro left a centering transform, clear it so absolute dragging is literal
-      if(sheetEl.style.transform){ sheetEl.style.transform=''; }
+      sheetEl.style.transform='none';
+      if(document.body.classList.contains('touch')){ sheetEl.dataset.touchFreed = '1'; }
     };
     const moveDrag=(clientX, clientY)=>{ if(!drag) return; const dx=clientX-sx, dy=clientY-sy; sheetEl.style.left=(sl+dx)+'px'; sheetEl.style.top=(st+dy)+'px'; sheetEl.style.bottom='auto'; };
     const endDrag=()=>{ if(!drag) return; drag=false; sheetEl.classList.remove('dragging'); sheetEl.style.transition=prevTrans||''; };
@@ -19466,29 +19472,65 @@ const UI = (()=>{
     // Touch-only minimize dot logic (appears post-intro)
     const minDot=document.getElementById('minDot');
     const sheet=document.getElementById('sheet');
+    let sheetMinimized=false;
+    let sheetRestoreIcon=null;
     function showMinDot(){ if(document.body.classList.contains('touch')){ minDot?.classList.add('show'); } }
     function hideMinDot(){ minDot?.classList.remove('show'); }
-    // Hook into intro end to reveal dot
-    const oldCollapse = UI.triggerIntroCollapse;
-    UI.triggerIntroCollapse = function(){ const r = oldCollapse?.call(UI); showMinDot(); return r; };
-    // Minimize behavior
-    let sheetMinimized=false;
-    function minimizeSheet(){ if(sheetMinimized) return; sheetMinimized=true; sheet.style.transform = (sheet.style.transform.includes('translateX(-50%)')? 'translateX(-50%)' : '') + ' translateY(12px) scale(0.92)'; sheet.style.opacity='0.0'; sheet.style.pointerEvents='none'; hideMinDot(); showSheetRestoreIcon(); }
-    minDot?.addEventListener('click', (e)=>{ e.stopPropagation(); minimizeSheet(); });
-
-    // Restore icon next to debug icon
-    function showSheetRestoreIcon(){
+    const applySheetBaseTransform=()=>{
+      if(!sheet) return;
+      if(document.body.classList.contains('touch')){
+        if(sheet.dataset.touchFreed==='1'){ sheet.style.transform='none'; }
+        else { sheet.style.transform='translateX(-50%)'; }
+      } else {
+        sheet.style.transform='';
+      }
+    };
+    const ensureSheetRestoreIcon=()=>{
+      if(!document.body.classList.contains('touch')) return null;
+      if(sheetRestoreIcon && document.body.contains(sheetRestoreIcon)) return sheetRestoreIcon;
       let icon=document.getElementById('sheet-restore');
       if(!icon){
         icon=document.createElement('div');
         icon.id='sheet-restore'; icon.className='ui-icon';
         icon.style.left='74px'; icon.style.bottom='24px'; icon.style.zIndex='10003';
         icon.title='Show Sheet';
+        icon.setAttribute('role','button');
+        icon.setAttribute('aria-label','Show Sheet');
+        icon.tabIndex=0;
         icon.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="14" rx="2"/><line x1="7" y1="8" x2="17" y2="8"/><line x1="7" y1="12" x2="14" y2="12"/><line x1="7" y1="16" x2="12" y2="16"/></svg>';
         document.body.appendChild(icon);
-        icon.addEventListener('click', ()=>{ sheet.style.opacity='1'; sheet.style.pointerEvents='auto'; sheet.style.transform= sheet.style.transform.includes('translateX(-50%)') ? 'translateX(-50%)' : ''; icon.remove(); sheetMinimized=false; showMinDot(); });
       }
-    }
+      if(icon && !icon._wired){
+        icon._wired=true;
+        icon.addEventListener('click',(e)=>{ e.preventDefault(); restoreSheet(); });
+        icon.addEventListener('keydown',(ev)=>{ if(ev.key==='Enter'||ev.key===' '){ ev.preventDefault(); restoreSheet(); } });
+      }
+      sheetRestoreIcon=icon;
+      return icon;
+    };
+    const updateSheetRestoreIcon=()=>{
+      const icon=ensureSheetRestoreIcon();
+      if(!icon) return;
+      icon.style.opacity = sheetMinimized ? '1' : '0.65';
+      icon.setAttribute('aria-hidden', sheetMinimized ? 'false' : 'true');
+    };
+    const restoreSheet=()=>{
+      if(!sheet) return;
+      sheet.style.opacity='1';
+      sheet.style.pointerEvents='auto';
+      if(document.body.classList.contains('touch')){ sheet.dataset.touchFreed='1'; }
+      applySheetBaseTransform();
+      sheetMinimized=false;
+      updateSheetRestoreIcon();
+      showMinDot();
+    };
+    // Hook into intro end to reveal dot
+    const oldCollapse = UI.triggerIntroCollapse;
+    UI.triggerIntroCollapse = function(){ const r = oldCollapse?.call(UI); showMinDot(); updateSheetRestoreIcon(); return r; };
+    // Minimize behavior
+    function minimizeSheet(){ if(sheetMinimized||!sheet) return; sheetMinimized=true; const base=(document.body.classList.contains('touch') && sheet.dataset.touchFreed!=='1')?'translateX(-50%) ':''; sheet.style.transform = `${base}translateY(12px) scale(0.92)`; sheet.style.opacity='0.0'; sheet.style.pointerEvents='none'; hideMinDot(); updateSheetRestoreIcon(); }
+    minDot?.addEventListener('click', (e)=>{ e.stopPropagation(); minimizeSheet(); });
+    updateSheetRestoreIcon();
 
     // Insert button handlers
     document.getElementById('insertRow')?.addEventListener('click',()=>{ 
@@ -19885,12 +19927,17 @@ const UI = (()=>{
         setTimeout(()=>{ header.classList.remove('wipe'); header.classList.remove('visible'); }, 700);
       }catch{}
       // Mobile card: center bottom with capped width and ~40vh height
-      sheetEl.style.width = Math.min(window.innerWidth*0.92, 680) + 'px';
-      sheetEl.style.height = Math.round(Math.min(window.innerHeight*0.40, 520)) + 'px';
-      sheetEl.style.left = '50%';
+      const targetWidth = Math.min(window.innerWidth*0.92, 680);
+      const targetHeight = Math.round(Math.min(window.innerHeight*0.40, 520));
+      const leftPx = Math.max(12, Math.round((window.innerWidth - targetWidth) / 2));
+      sheetEl.style.width = targetWidth + 'px';
+      sheetEl.style.height = targetHeight + 'px';
+      sheetEl.style.left = leftPx + 'px';
+      sheetEl.style.right = 'auto';
       sheetEl.style.bottom = '12px';
       sheetEl.style.top = '';
-      sheetEl.style.transform = 'translateX(-50%)';
+      sheetEl.style.transform = 'none';
+      sheetEl.dataset.touchFreed = '1';
     } else {
       // Desktop: bottom-left similar to launch size
       const vw = Math.max(720, Math.floor(window.innerWidth * 0.42));
@@ -19912,6 +19959,7 @@ const UI = (()=>{
       sheetEl.style.top = '';
       sheetEl.style.bottom = '16px';
       sheetEl.style.transform = '';
+      sheetEl.dataset.touchFreed = '0';
     }
     // Mark sheet as user-sized after intro so renderSheet doesn't resize it
     sheetEl.dataset.userSized = '1';


### PR DESCRIPTION
## Summary
- ensure the touch intro collapse centers the sheet without using translate offsets and track the freed state
- update drag/minimize/restore logic to respect the touch-free transform and expose a dedicated restore icon on touch devices
- create an always-available mobile "Show Sheet" control beside the debug toggle with keyboard support

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e46d5435e08329919f20b3d6a4106b