### PR TITLE
Fix dpad double movement on touch input

### DIFF
--- a/index.html
+++ b/index.html
@@ -19869,6 +19869,7 @@ const UI = (()=>{
       try{ UI?.syncPresentUI?.(actual); }catch(e){ console.warn('Sync present UI failed', e); }
       syncPresentToggle();
     };
+    let lastDpadTouchTime = 0;
     dpad.querySelectorAll('.dp').forEach(btn=>{
       if(btn.classList.contains('grab')) return;
       const clickHandler = ()=>{
@@ -19888,8 +19889,18 @@ const UI = (()=>{
         if(!direction) return;
         onDP(direction);
       };
-      btn.addEventListener('click', clickHandler);
-      btn.addEventListener('touchend', (e)=>{ e.preventDefault(); clickHandler(); }, {passive:false});
+      btn.addEventListener('click', (e)=>{
+        if(Date.now() - lastDpadTouchTime < 400){
+          console.log('[DPAD] Ignoring click synthesized from touch');
+          return;
+        }
+        clickHandler();
+      });
+      btn.addEventListener('touchend', (e)=>{
+        lastDpadTouchTime = Date.now();
+        e.preventDefault();
+        clickHandler();
+      }, {passive:false});
     });
     syncPresentToggle();
     // Reflect current arrow mapping (height vs depth) on center key


### PR DESCRIPTION
## Summary
- prevent touch interactions on the dpad from triggering an additional synthesized click
- track the last touch time and ignore subsequent click events to keep navigation single-stepped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c54abd788329afa006393a9af0f9